### PR TITLE
feat: add initialization and unify CLI commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # 🚀 XOps CLI
 
 <div align="center">
-  <h3>新一代 AI 驱动的全能运维命令行工具箱</h3>
+  <h3>让 AI 在安全边界内管理远程主机</h3>
   
   <p>
     <img alt="Go Version" src="https://img.shields.io/badge/Go-1.26+-00ADD8?style=flat&logo=go" />
@@ -15,9 +15,7 @@
 
 ---
 
-**XOps CLI** 是一个基于 Go 语言开发的现代化命令行运维工具集，旨在简化并自动化日常的服务器管理工作。
-
-除了传统的 SSH 管理和批量执行功能外，XOps 原生集成了 **Model Context Protocol (MCP)** 服务端，允许 AI Agent (如 Claude 等) 在安全护栏下直接与你的基础设施进行交互。它是连接 AI 助手与真实服务器环境的完美桥梁。
+**XOps CLI** 统一管理主机资产、SSH、批量执行与 Playbook，并通过内置的 **Model Context Protocol (MCP)** 安全护栏，让 AI Agent 在可审批、可审计的边界内操作远程主机。
 
 ### ✨ 核心特性
 
@@ -31,7 +29,13 @@
 
 ### 📦 安装指南
 
-**环境要求:** Go 1.26 或更高版本。
+使用预编译版本安装（Linux/macOS）：
+
+```bash
+curl -sSL https://raw.githubusercontent.com/wentf9/xops-cli/master/install.sh | bash
+```
+
+从源码构建需要 Go 1.26 或更高版本：
 
 ```bash
 git clone https://github.com/wentf9/xops-cli.git
@@ -42,21 +46,37 @@ make build
 
 ### 🚀 快速上手
 
-#### 1. 主机与资产管理
+#### 1. 初始化
+
+```bash
+# 创建 ~/.xops/xops_config.yaml 和加密密钥
+# 默认导入 ~/.ssh/config 中不含通配符的 Host；不会连接远程主机
+xops init
+
+# 使用指定的 OpenSSH 配置，或完全跳过导入
+xops init --ssh-config ~/.ssh/config.work
+xops init --skip-ssh-import
+```
+
+该命令可重复执行，不会覆盖已有节点。初始化完成后可运行 `xops host list` 查看导入结果。
+
+#### 2. 主机与资产管理
 
 ```bash
 # 从 CSV 文件批量导入主机，并打上 'web' 标签
-xops loadHost hosts.csv -t web
+xops host import hosts.csv --tag web
 
 # 手动添加单台主机
-xops host add --name web-01 --address 192.168.1.10 --user root --tag web
+xops host add --address 192.168.1.10 --user root --key ~/.ssh/id_ed25519 --alias web-01 --tags web
 
 # 查看主机列表或标签
 xops host list
 xops host tags
 ```
 
-#### 2. SSH 连接与 TUI
+`inventory` 仍可作为 `host` 的兼容别名，`host load` 仍可作为 `host import` 的兼容别名；新脚本应使用上面的规范命令。
+
+#### 3. SSH 连接与 TUI
 
 ```bash
 # 启动交互式 TUI 界面管理
@@ -72,7 +92,7 @@ xops ssh -J jumphost -i ~/.ssh/id_rsa root@192.168.1.13
 xops ssh --sudo web-01
 ```
 
-#### 3. 批量执行与文件分发
+#### 4. 批量执行与文件分发
 
 ```bash
 # 对 web 标签组的所有主机并行执行 uptime 命令
@@ -85,7 +105,7 @@ xops exec --tag web --shell ./setup.sh --task 5
 xops scp ./config.conf --tag web --dest /etc/app/
 ```
 
-#### 4. 声明式任务编排 (Playbook)
+#### 5. 声明式任务编排 (Playbook)
 
 你可以编写 YAML 格式的 Playbook 实现流水线式的复杂部署任务。支持 shell、script、copy、ensure (状态期望收敛)、template 等操作。
 
@@ -129,7 +149,7 @@ xops play deploy.yaml --dry-run
 xops play deploy.yaml --limit web-01
 ```
 
-#### 5. AI 与 MCP 集成 (赋予 AI 运维能力)
+#### 6. AI 与 MCP 集成 (赋予 AI 运维能力)
 
 XOps 内置了 **Model Context Protocol (MCP)** 服务端，让 **Claude** 等 AI 助手可以直接感知并操作你的服务器。
 
@@ -159,7 +179,7 @@ xops mcp serve
 - **策略控制**: 支持配置只读模式或“先审批后执行”策略。
 - **全量审计**: 完整记录 AI 执行的每一条指令，确保过程透明可追溯。
 
-#### 6. AI Agent 技能 (Skill) 集成
+#### 7. AI Agent 技能 (Skill) 集成
 
 XOps 提供开箱即用的 AI Agent 技能 (Skill)，让你的命令行 AI 助手一键获得强大的服务器运维和故障排查能力。
 

--- a/README_en.md
+++ b/README_en.md
@@ -1,7 +1,7 @@
 # 🚀 XOps CLI
 
 <div align="center">
-  <h3>A Next-Generation, AI-Ready IT Operations Toolkit</h3>
+  <h3>Let AI manage remote hosts within explicit safety boundaries</h3>
   
   <p>
     <img alt="Go Version" src="https://img.shields.io/badge/Go-1.26+-00ADD8?style=flat&logo=go" />
@@ -15,9 +15,7 @@
 
 ---
 
-**XOps CLI** is a powerful, modern CLI toolkit written in Go, designed to streamline and automate daily server management and IT operations.
-
-Beyond standard SSH and batch execution, XOps natively integrates the **Model Context Protocol (MCP)**, allowing AI Agents (like Claude) to directly interact with your infrastructure securely. It is the perfect bridge between AI assistants and your servers.
+**XOps CLI** combines host inventory, SSH, batch execution, and Playbooks with built-in **Model Context Protocol (MCP)** guardrails, allowing AI Agents to operate remote hosts within approval and audit boundaries.
 
 ### ✨ Key Features
 
@@ -31,7 +29,13 @@ Beyond standard SSH and batch execution, XOps natively integrates the **Model Co
 
 ### 📦 Installation
 
-**Prerequisites:** Go 1.26 or higher.
+Install a pre-built binary on Linux or macOS:
+
+```bash
+curl -sSL https://raw.githubusercontent.com/wentf9/xops-cli/master/install.sh | bash
+```
+
+Building from source requires Go 1.26 or higher:
 
 ```bash
 git clone https://github.com/wentf9/xops-cli.git
@@ -42,21 +46,37 @@ make build
 
 ### 🚀 Quick Start
 
-#### 1. Inventory & Tags
+#### 1. Initialize
+
+```bash
+# Create ~/.xops/xops_config.yaml and its encryption key.
+# Concrete Hosts from ~/.ssh/config are imported without connecting to them.
+xops init
+
+# Use another OpenSSH config, or skip the import entirely.
+xops init --ssh-config ~/.ssh/config.work
+xops init --skip-ssh-import
+```
+
+The command is idempotent and never overwrites existing nodes. Run `xops host list` to review the result.
+
+#### 2. Inventory & Tags
 
 ```bash
 # Import hosts from CSV and tag them as 'web'
-xops loadHost hosts.csv -t web
+xops host import hosts.csv --tag web
 
 # Add a single host manually
-xops host add --name web-01 --address 192.168.1.10 --user root --tag web
+xops host add --address 192.168.1.10 --user root --key ~/.ssh/id_ed25519 --alias web-01 --tags web
 
 # List all hosts or tags
 xops host list
 xops host tags
 ```
 
-#### 2. SSH & TUI
+`inventory` remains a compatibility alias for `host`, and `host load` remains an alias for `host import`. New scripts should use the canonical commands above.
+
+#### 3. SSH & TUI
 
 ```bash
 # Launch interactive TUI
@@ -73,7 +93,7 @@ xops ssh --sudo web-01
 
 ```
 
-#### 3. Batch Execution & File Transfer
+#### 4. Batch Execution & File Transfer
 
 ```bash
 # Execute 'uptime' on all 'web' servers
@@ -86,7 +106,7 @@ xops exec --tag web --shell ./setup.sh --task 5
 xops scp ./config.conf --tag web --dest /etc/app/
 ```
 
-#### 4. Declarative Orchestration (Playbook)
+#### 5. Declarative Orchestration (Playbook)
 
 You can write YAML-formatted Playbooks to execute complex, multi-stage deployment workflows. It supports shell, script, copy, ensure (idempotent state convergence), and template actions.
 
@@ -130,7 +150,7 @@ xops play deploy.yaml --dry-run
 xops play deploy.yaml --limit web-01
 ```
 
-#### 5. AI & MCP Integration (Empower your AI Agent)
+#### 6. AI & MCP Integration (Empower your AI Agent)
 
 XOps features a built-in **Model Context Protocol (MCP)** server, allowing AI assistants like **Claude** to explore and manage your infrastructure under your control.
 
@@ -160,7 +180,7 @@ Add the following to your `claude_desktop_config.json` to let Claude use XOps:
 - **Policy Control**: Supports "Audit-only" or "Manual Approval" modes.
 - **Audit Logs**: Full transparency on what the AI is doing on your servers.
 
-#### 6. AI Agent Skill Integration
+#### 7. AI Agent Skill Integration
 
 XOps comes with an out-of-the-box AI Agent Skill, empowering your terminal-based AI assistant with robust server management and troubleshooting capabilities.
 

--- a/cmd/command_tree_test.go
+++ b/cmd/command_tree_test.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestCommandTreeUsesCanonicalCommands(t *testing.T) {
+	root := newRootCmd()
+	initRootFlags(root)
+	registerCommands(root)
+
+	hostCmd, _, err := root.Find([]string{"host"})
+	if err != nil {
+		t.Fatalf("find host command: %v", err)
+	}
+	if hostCmd.Name() != "host" {
+		t.Errorf("host command name = %q, want host", hostCmd.Name())
+	}
+	if !slices.Contains(hostCmd.Aliases, "inventory") {
+		t.Errorf("host aliases = %v, want backward-compatible inventory alias", hostCmd.Aliases)
+	}
+
+	importCmd, _, err := root.Find([]string{"host", "import"})
+	if err != nil {
+		t.Fatalf("find host import command: %v", err)
+	}
+	if importCmd.Name() != "import" || !slices.Contains(importCmd.Aliases, "load") {
+		t.Errorf("host import command = %q aliases %v", importCmd.Name(), importCmd.Aliases)
+	}
+
+	mcpServeCmd, _, err := root.Find([]string{"mcp", "serve"})
+	if err != nil {
+		t.Fatalf("find mcp serve command: %v", err)
+	}
+	if mcpServeCmd.Name() != "serve" {
+		t.Errorf("mcp serve command name = %q, want serve", mcpServeCmd.Name())
+	}
+
+	legacyCmd, _, err := root.Find([]string{"loadHost"})
+	if err != nil {
+		t.Fatalf("find legacy loadHost command: %v", err)
+	}
+	if !legacyCmd.Hidden || legacyCmd.Deprecated == "" {
+		t.Errorf("legacy loadHost command should be hidden and deprecated")
+	}
+}
+
+func TestMCPCommandRejectsUnknownArguments(t *testing.T) {
+	cmd := NewCmdMcp()
+	if err := cmd.Args(cmd, []string{"unknown"}); err == nil {
+		t.Fatal("mcp Args() error = nil, want unknown argument error")
+	}
+}

--- a/cmd/host/host.go
+++ b/cmd/host/host.go
@@ -7,12 +7,13 @@ import (
 
 func NewCmdInventory() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "inventory",
-		Aliases: []string{"host", "hosts", "inv"},
+		Use:     "host",
+		Aliases: []string{"hosts", "inventory", "inv"},
 		Short:   i18n.T("inventory_short"),
 		Long:    i18n.T("inventory_long"),
-		Run: func(cmd *cobra.Command, args []string) {
-			_ = cmd.Help()
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
 		},
 	}
 
@@ -31,8 +32,9 @@ func NewCmdInventoryTag() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "tag",
 		Short: i18n.T("inventory_tag_short"),
-		Run: func(cmd *cobra.Command, args []string) {
-			_ = cmd.Help()
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
 		},
 	}
 

--- a/cmd/host/load.go
+++ b/cmd/host/load.go
@@ -23,10 +23,12 @@ var Tag string
 
 func NewCmdInventoryLoad() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "load [csv_file]",
-		Short: i18n.T("inventory_load_short"),
-		Long:  i18n.T("inventory_load_long"),
-		RunE:  RunInventoryLoad,
+		Use:     "import [csv_file]",
+		Aliases: []string{"load"},
+		Short:   i18n.T("inventory_load_short"),
+		Long:    i18n.T("inventory_load_long"),
+		Args:    cobra.MaximumNArgs(1),
+		RunE:    RunInventoryLoad,
 	}
 
 	cmd.Flags().StringVarP(&TemplateFile, "template", "T", "", i18n.T("flag_inv_template"))

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,0 +1,202 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"github.com/wentf9/xops-cli/cmd/utils"
+	"github.com/wentf9/xops-cli/pkg/config"
+	"github.com/wentf9/xops-cli/pkg/i18n"
+)
+
+// InitOptions contains the filesystem-only settings for xops init.
+type InitOptions struct {
+	ConfigPath       string
+	KeyPath          string
+	SSHConfigPath    string
+	SSHConfigChanged bool
+	SkipSSHImport    bool
+}
+
+type initResult struct {
+	configCreated bool
+	imported      int
+	skipped       int
+}
+
+// NewInitOptions creates initialization options with the default OpenSSH path.
+func NewInitOptions() *InitOptions {
+	return &InitOptions{SSHConfigPath: defaultSSHConfigPath()}
+}
+
+// NewCmdInit creates the command that initializes local XOps configuration.
+func NewCmdInit() *cobra.Command {
+	o := NewInitOptions()
+	cmd := &cobra.Command{
+		Use:   "init",
+		Short: i18n.T("init_short"),
+		Long:  i18n.T("init_long"),
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			o.SSHConfigChanged = cmd.Flags().Changed("ssh-config")
+			result, err := o.Run()
+			if err != nil {
+				return err
+			}
+			return o.printResult(cmd, result)
+		},
+	}
+
+	cmd.Flags().StringVar(&o.SSHConfigPath, "ssh-config", o.SSHConfigPath, i18n.T("flag_init_ssh_config"))
+	cmd.Flags().BoolVar(&o.SkipSSHImport, "skip-ssh-import", false, i18n.T("flag_init_skip_ssh_import"))
+	cmd.MarkFlagsMutuallyExclusive("ssh-config", "skip-ssh-import")
+	return cmd
+}
+
+// Run creates the local configuration and imports concrete OpenSSH hosts.
+// It never performs network operations and never overwrites existing nodes.
+func (o *InitOptions) Run() (initResult, error) {
+	if o.ConfigPath == "" || o.KeyPath == "" {
+		o.ConfigPath, o.KeyPath = utils.GetConfigFilePath()
+	}
+	if o.ConfigPath == "" || o.KeyPath == "" {
+		return initResult{}, fmt.Errorf("resolve xops configuration paths")
+	}
+
+	configCreated, err := configurationNeedsCreation(o.ConfigPath)
+	if err != nil {
+		return initResult{}, err
+	}
+
+	store := config.NewDefaultStore(o.ConfigPath, o.KeyPath)
+	cfg, err := store.Load()
+	if err != nil {
+		return initResult{}, fmt.Errorf("load xops configuration: %w", err)
+	}
+	provider := config.NewProvider(cfg)
+
+	result := initResult{configCreated: configCreated}
+	if !o.SkipSSHImport && o.SSHConfigPath != "" {
+		hosts, loadErr := loadOpenSSHHosts(o.SSHConfigPath, utils.GetCurrentUser())
+		if loadErr != nil {
+			if !errors.Is(loadErr, os.ErrNotExist) || o.SSHConfigChanged {
+				return initResult{}, loadErr
+			}
+		} else {
+			result.imported, result.skipped = importOpenSSHHosts(provider, hosts)
+		}
+	}
+
+	if result.configCreated || result.imported > 0 {
+		if err := store.Save(cfg); err != nil {
+			return initResult{}, fmt.Errorf("save xops configuration: %w", err)
+		}
+	}
+	return result, nil
+}
+
+func (o *InitOptions) printResult(cmd *cobra.Command, result initResult) error {
+	statusKey := "init_status_existing"
+	if result.configCreated {
+		statusKey = "init_status_created"
+	}
+	if _, err := fmt.Fprintln(cmd.OutOrStdout(), i18n.T(statusKey)); err != nil {
+		return fmt.Errorf("write initialization status: %w", err)
+	}
+	if _, err := fmt.Fprintln(cmd.OutOrStdout(), i18n.Tf("init_config_path", map[string]any{"Path": o.ConfigPath})); err != nil {
+		return fmt.Errorf("write configuration path: %w", err)
+	}
+	if _, err := fmt.Fprintln(cmd.OutOrStdout(), i18n.Tf("init_key_path", map[string]any{"Path": o.KeyPath})); err != nil {
+		return fmt.Errorf("write key path: %w", err)
+	}
+	if _, err := fmt.Fprintln(cmd.OutOrStdout(), i18n.Tf("init_import_summary", map[string]any{
+		"Imported": result.imported,
+		"Skipped":  result.skipped,
+	})); err != nil {
+		return fmt.Errorf("write openssh import summary: %w", err)
+	}
+	if _, err := fmt.Fprintln(cmd.OutOrStdout(), i18n.T("init_next_steps")); err != nil {
+		return fmt.Errorf("write initialization next steps: %w", err)
+	}
+	return nil
+}
+
+func configurationNeedsCreation(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if err == nil {
+		return false, nil
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		return true, nil
+	}
+	return false, fmt.Errorf("inspect xops configuration %q: %w", path, err)
+}
+
+func loadOpenSSHHosts(path, defaultUser string) (hosts []config.OpenSSHHost, err error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open openssh configuration %q: %w", path, err)
+	}
+	defer func() {
+		if closeErr := f.Close(); closeErr != nil {
+			err = errors.Join(err, fmt.Errorf("close openssh configuration %q: %w", path, closeErr))
+		}
+	}()
+
+	hosts, err = config.ParseOpenSSHHosts(f, defaultUser)
+	if err != nil {
+		return nil, fmt.Errorf("load openssh configuration %q: %w", path, err)
+	}
+	return hosts, nil
+}
+
+func importOpenSSHHosts(provider config.ConfigProvider, hosts []config.OpenSSHHost) (imported, skipped int) {
+	added := make([]string, 0, len(hosts))
+	for _, item := range hosts {
+		if provider.Find(item.Name) != "" {
+			skipped++
+			continue
+		}
+
+		hostRef := "openssh-host:" + item.Name
+		identityRef := "openssh-identity:" + item.Name
+		item.Node.HostRef = hostRef
+		item.Node.IdentityRef = identityRef
+		provider.AddHost(hostRef, item.Host)
+		provider.AddIdentity(identityRef, item.Identity)
+		provider.AddNode(item.Name, item.Node)
+		added = append(added, item.Name)
+		imported++
+	}
+
+	for _, nodeID := range added {
+		node, ok := provider.GetNode(nodeID)
+		if !ok || node.ProxyJump == "" {
+			continue
+		}
+		if jumpNodeID := findProxyJumpNode(provider, node.ProxyJump); jumpNodeID != "" {
+			node.ProxyJump = jumpNodeID
+			provider.AddNode(nodeID, node)
+		}
+	}
+	return imported, skipped
+}
+
+func findProxyJumpNode(provider config.ConfigProvider, value string) string {
+	if nodeID := provider.Find(value); nodeID != "" {
+		return nodeID
+	}
+	_, host, _ := utils.ParseAddr(value)
+	return provider.Find(host)
+}
+
+func defaultSSHConfigPath() string {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(homeDir, ".ssh", "config")
+}

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -1,0 +1,94 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/wentf9/xops-cli/pkg/config"
+)
+
+func TestInitOptions_RunCreatesConfigAndImportsOpenSSH(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	sshConfigPath := filepath.Join(tempDir, "ssh_config")
+	sshConfig := []byte("Host jump\n  HostName bastion.example.com\nHost app\n  HostName 10.0.0.10\n  ProxyJump jump\n")
+	if err := os.WriteFile(sshConfigPath, sshConfig, 0o600); err != nil {
+		t.Fatalf("write SSH config: %v", err)
+	}
+
+	o := &InitOptions{
+		ConfigPath:    filepath.Join(tempDir, "xops", "xops_config.yaml"),
+		KeyPath:       filepath.Join(tempDir, "xops", "secret.key"),
+		SSHConfigPath: sshConfigPath,
+	}
+	result, err := o.Run()
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if !result.configCreated || result.imported != 2 || result.skipped != 0 {
+		t.Fatalf("Run() result = %#v, want created with 2 imports", result)
+	}
+
+	store := config.NewDefaultStore(o.ConfigPath, o.KeyPath)
+	cfg, err := store.Load()
+	if err != nil {
+		t.Fatalf("load initialized config: %v", err)
+	}
+	if len(cfg.Nodes.Keys()) != 2 {
+		t.Fatalf("initialized node count = %d, want 2", len(cfg.Nodes.Keys()))
+	}
+	app, ok := cfg.Nodes.Get("app")
+	if !ok {
+		t.Fatal("initialized config does not contain app")
+	}
+	if app.ProxyJump != "jump" {
+		t.Errorf("app ProxyJump = %q, want jump", app.ProxyJump)
+	}
+	if _, err := os.Stat(o.KeyPath); err != nil {
+		t.Fatalf("secret key was not created: %v", err)
+	}
+
+	result, err = o.Run()
+	if err != nil {
+		t.Fatalf("second Run() error = %v", err)
+	}
+	if result.configCreated || result.imported != 0 || result.skipped != 2 {
+		t.Fatalf("second Run() result = %#v, want idempotent skips", result)
+	}
+}
+
+func TestInitOptions_RunExplicitMissingSSHConfigFails(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	o := &InitOptions{
+		ConfigPath:       filepath.Join(tempDir, "xops_config.yaml"),
+		KeyPath:          filepath.Join(tempDir, "secret.key"),
+		SSHConfigPath:    filepath.Join(tempDir, "missing"),
+		SSHConfigChanged: true,
+	}
+	if _, err := o.Run(); err == nil {
+		t.Fatal("Run() error = nil, want missing explicit SSH config error")
+	}
+}
+
+func TestInitOptions_RunSkipsOpenSSHImport(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	o := &InitOptions{
+		ConfigPath:    filepath.Join(tempDir, "xops_config.yaml"),
+		KeyPath:       filepath.Join(tempDir, "secret.key"),
+		SSHConfigPath: filepath.Join(tempDir, "missing"),
+		SkipSSHImport: true,
+	}
+	result, err := o.Run()
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if !result.configCreated || result.imported != 0 {
+		t.Fatalf("Run() result = %#v, want empty initialized config", result)
+	}
+}

--- a/cmd/loadHost.go
+++ b/cmd/loadHost.go
@@ -8,10 +8,13 @@ import (
 
 func newCmdLoadHost() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "loadHost [csv_file]",
-		Short: i18n.T("loadhost_short"),
-		Long:  i18n.T("loadhost_long"),
-		RunE:  host.RunInventoryLoad,
+		Use:        "loadHost [csv_file]",
+		Short:      i18n.T("loadhost_short"),
+		Long:       i18n.T("loadhost_long"),
+		Args:       cobra.MaximumNArgs(1),
+		RunE:       host.RunInventoryLoad,
+		Hidden:     true,
+		Deprecated: "use 'xops host import' instead",
 	}
 
 	cmd.Flags().StringVarP(&host.TemplateFile, "template", "T", "", i18n.T("flag_inv_template"))

--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -18,24 +18,38 @@ func NewCmdMcp() *cobra.Command {
 		Use:   "mcp",
 		Short: i18n.T("mcp_short"),
 		Long:  i18n.T("mcp_long"),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			// MCP server 必须完全静默，避免污染 stdout json-rpc 流
-			logger.SetLogLevel("none")
-
-			ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-			defer stop()
-
-			err := mcpserver.Serve(ctx)
-			if err != nil {
-				if strings.Contains(err.Error(), "EOF") || strings.Contains(err.Error(), "closing") {
-					return nil
-				}
-				return err
-			}
-			return nil
-		},
+		Args:  cobra.NoArgs,
+		RunE:  runMCPServer,
 	}
 	cmd.SilenceUsage = true
 	cmd.SilenceErrors = true
+	cmd.AddCommand(newCmdMCPServe())
 	return cmd
+}
+
+func newCmdMCPServe() *cobra.Command {
+	return &cobra.Command{
+		Use:   "serve",
+		Short: i18n.T("mcp_serve_short"),
+		Long:  i18n.T("mcp_long"),
+		Args:  cobra.NoArgs,
+		RunE:  runMCPServer,
+	}
+}
+
+func runMCPServer(cmd *cobra.Command, args []string) error {
+	// MCP server 必须完全静默，避免污染 stdout json-rpc 流
+	logger.SetLogLevel("none")
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	err := mcpserver.Serve(ctx)
+	if err != nil {
+		if strings.Contains(err.Error(), "EOF") || strings.Contains(err.Error(), "closing") {
+			return nil
+		}
+		return err
+	}
+	return nil
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -84,6 +84,7 @@ func initRootFlags(rootCmd *cobra.Command) {
 
 func registerCommands(rootCmd *cobra.Command) {
 	// 注册各子命令
+	rootCmd.AddCommand(NewCmdInit())
 	rootCmd.AddCommand(host.NewCmdInventory())
 	rootCmd.AddCommand(newCmdVersion())
 	rootCmd.AddCommand(NewCmdSsh())

--- a/pkg/config/openssh_import.go
+++ b/pkg/config/openssh_import.go
@@ -1,0 +1,120 @@
+package config
+
+import (
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
+	"github.com/kevinburke/ssh_config"
+	"github.com/wentf9/xops-cli/pkg/models"
+)
+
+// OpenSSHHost is a concrete Host entry that can be persisted in the XOps inventory.
+// Wildcard and negated patterns are intentionally excluded because they do not
+// identify a single inventory node.
+type OpenSSHHost struct {
+	Name     string
+	Host     models.Host
+	Identity models.Identity
+	Node     models.Node
+}
+
+// ParseOpenSSHHosts parses concrete Host entries from an OpenSSH configuration.
+// It does not connect to any remote host or modify the source configuration.
+func ParseOpenSSHHosts(r io.Reader, defaultUser string) ([]OpenSSHHost, error) {
+	cfg, err := ssh_config.Decode(r)
+	if err != nil {
+		return nil, fmt.Errorf("parse openssh configuration: %w", err)
+	}
+
+	hosts := make([]OpenSSHHost, 0)
+	seen := make(map[string]struct{})
+	for _, block := range cfg.Hosts {
+		for _, pattern := range block.Patterns {
+			name := pattern.String()
+			if !isConcreteSSHHost(name) {
+				continue
+			}
+			if _, ok := seen[name]; ok {
+				continue
+			}
+
+			host, err := openSSHHostFromConfig(cfg, name, defaultUser)
+			if err != nil {
+				return nil, err
+			}
+			hosts = append(hosts, host)
+			seen[name] = struct{}{}
+		}
+	}
+
+	return hosts, nil
+}
+
+func isConcreteSSHHost(pattern string) bool {
+	return pattern != "" &&
+		!strings.HasPrefix(pattern, "!") &&
+		!strings.ContainsAny(pattern, "*?")
+}
+
+func openSSHHostFromConfig(cfg *ssh_config.Config, name, defaultUser string) (OpenSSHHost, error) {
+	address, err := openSSHValue(cfg, name, "HostName", name)
+	if err != nil {
+		return OpenSSHHost{}, err
+	}
+	user, err := openSSHValue(cfg, name, "User", defaultUser)
+	if err != nil {
+		return OpenSSHHost{}, err
+	}
+	portValue, err := openSSHValue(cfg, name, "Port", "22")
+	if err != nil {
+		return OpenSSHHost{}, err
+	}
+	port, err := strconv.ParseUint(strings.TrimSpace(portValue), 10, 16)
+	if err != nil || port == 0 {
+		return OpenSSHHost{}, fmt.Errorf("parse openssh port for host %q: %q", name, portValue)
+	}
+	keyPath, err := openSSHValue(cfg, name, "IdentityFile", "")
+	if err != nil {
+		return OpenSSHHost{}, err
+	}
+	proxyJump, err := openSSHValue(cfg, name, "ProxyJump", "")
+	if err != nil {
+		return OpenSSHHost{}, err
+	}
+	if strings.EqualFold(proxyJump, "none") {
+		proxyJump = ""
+	}
+
+	return OpenSSHHost{
+		Name: name,
+		Host: models.Host{
+			Address: address,
+			Port:    uint16(port),
+		},
+		Identity: models.Identity{
+			User:     user,
+			AuthType: "auto",
+			KeyPath:  expandHomeDir(keyPath),
+		},
+		Node: models.Node{
+			Alias:     []string{name},
+			Tags:      []string{"openssh"},
+			ProxyJump: proxyJump,
+			SudoMode:  models.SudoModeAuto,
+		},
+	}, nil
+}
+
+func openSSHValue(cfg *ssh_config.Config, host, key, fallback string) (string, error) {
+	value, err := cfg.Get(host, key)
+	if err != nil {
+		return "", fmt.Errorf("read openssh %s for host %q: %w", key, host, err)
+	}
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return fallback, nil
+	}
+	return value, nil
+}

--- a/pkg/config/openssh_import_test.go
+++ b/pkg/config/openssh_import_test.go
@@ -1,0 +1,68 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseOpenSSHHosts(t *testing.T) {
+	t.Parallel()
+
+	const input = `
+Host *
+    ServerAliveInterval 30
+
+Host jump
+    HostName bastion.example.com
+    User ops
+    Port 2222
+    IdentityFile /keys/ops
+
+Host web-*
+    User deploy
+
+Host app
+    HostName 10.0.0.10
+    User deploy
+    ProxyJump jump
+
+Host app
+    HostName ignored.example.com
+`
+
+	hosts, err := ParseOpenSSHHosts(strings.NewReader(input), "local-user")
+	if err != nil {
+		t.Fatalf("ParseOpenSSHHosts() error = %v", err)
+	}
+	if len(hosts) != 2 {
+		t.Fatalf("ParseOpenSSHHosts() returned %d hosts, want 2", len(hosts))
+	}
+
+	jump := hosts[0]
+	if jump.Name != "jump" || jump.Host.Address != "bastion.example.com" || jump.Host.Port != 2222 {
+		t.Errorf("unexpected jump host: %#v", jump)
+	}
+	if jump.Identity.User != "ops" || jump.Identity.AuthType != "auto" || jump.Identity.KeyPath != "/keys/ops" {
+		t.Errorf("unexpected jump identity: %#v", jump.Identity)
+	}
+
+	app := hosts[1]
+	if app.Name != "app" || app.Host.Address != "10.0.0.10" || app.Host.Port != 22 {
+		t.Errorf("unexpected app host: %#v", app)
+	}
+	if app.Node.ProxyJump != "jump" {
+		t.Errorf("app ProxyJump = %q, want %q", app.Node.ProxyJump, "jump")
+	}
+	if len(app.Node.Tags) != 1 || app.Node.Tags[0] != "openssh" {
+		t.Errorf("app tags = %v, want [openssh]", app.Node.Tags)
+	}
+}
+
+func TestParseOpenSSHHosts_InvalidPort(t *testing.T) {
+	t.Parallel()
+
+	_, err := ParseOpenSSHHosts(strings.NewReader("Host broken\n  Port invalid\n"), "user")
+	if err == nil {
+		t.Fatal("ParseOpenSSHHosts() error = nil, want invalid port error")
+	}
+}

--- a/pkg/config/store.go
+++ b/pkg/config/store.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"sync"
@@ -33,7 +34,10 @@ func (s *defaultStore) Load() (*Configuration, error) {
 	// 1. 读取文件
 	data, err := os.ReadFile(s.Path)
 	if err != nil {
-		return &config, nil
+		if errors.Is(err, os.ErrNotExist) {
+			return &config, nil
+		}
+		return nil, fmt.Errorf("failed to read configuration file %s: %w", s.Path, err)
 	}
 	// 2. yaml.Unmarshal
 	if err = yaml.Unmarshal(data, &config); err != nil {

--- a/pkg/config/store_test.go
+++ b/pkg/config/store_test.go
@@ -99,6 +99,15 @@ func TestLoad_EmptyFile(t *testing.T) {
 	}
 }
 
+func TestLoad_ReadFailure(t *testing.T) {
+	dir := t.TempDir()
+	store := NewDefaultStore(dir, filepath.Join(dir, "config.key"))
+
+	if _, err := store.Load(); err == nil {
+		t.Fatal("Load() error = nil, want read failure")
+	}
+}
+
 func TestSave_EncryptsPassword(t *testing.T) {
 	store, cfg := newTestStoreAndConfig(t)
 	s := store.(*defaultStore)

--- a/pkg/i18n/i18n_test.go
+++ b/pkg/i18n/i18n_test.go
@@ -36,7 +36,7 @@ func TestT_Chinese(t *testing.T) {
 	if got == "root_short" {
 		t.Errorf("expected translated string, got key %q", got)
 	}
-	if got != "xops(XOps)是一个命令行工具集,用于日常运维和开发工作" {
+	if got != "安全管理和自动化远程主机的命令行工具" {
 		t.Errorf("unexpected translation: %q", got)
 	}
 }
@@ -47,7 +47,7 @@ func TestT_English(t *testing.T) {
 	if got == "root_short" {
 		t.Errorf("expected translated string, got key %q", got)
 	}
-	expected := "xops (XOps) is a CLI toolkit for daily operations and development"
+	expected := "Safely manage and automate remote hosts"
 	if got != expected {
 		t.Errorf("expected %q, got %q", expected, got)
 	}
@@ -89,7 +89,7 @@ func TestSetLang(t *testing.T) {
 		t.Errorf("expected en after SetLang, got %s", Lang())
 	}
 	got := T("root_short")
-	if got == "xops(XOps)是一个命令行工具集,用于日常运维和开发工作" {
+	if got == "安全管理和自动化远程主机的命令行工具" {
 		t.Errorf("expected english after SetLang, got chinese")
 	}
 }

--- a/pkg/i18n/locales/active.en.yaml
+++ b/pkg/i18n/locales/active.en.yaml
@@ -4,9 +4,9 @@
 
 # ---- root ----
 root_short:
-  other: "xops (XOps) is a CLI toolkit for daily operations and development"
+  other: "Safely manage and automate remote hosts"
 root_long:
-  other: "xops (XOps) is a CLI toolkit\nproviding a variety of utilities to improve daily operations and development efficiency."
+  other: "XOps combines host inventory, SSH, batch execution, playbooks, and MCP guardrails to safely manage and automate remote hosts."
 version_short:
   other: "Print the version number"
 flag_version:
@@ -312,9 +312,9 @@ inventory_delete_short:
 inventory_tags_short:
   other: "List all tags with node counts"
 inventory_load_short:
-  other: "Load hosts and credentials from CSV and verify"
+  other: "Import hosts and credentials from CSV and verify"
 inventory_load_long:
-  other: "Load hosts, usernames, and passwords from a CSV file and save to config.\nSupported headers: host, port, alias, user, password, key, keypass\nEstablishes SSH connections to verify credentials."
+  other: "Import hosts, usernames, and passwords from a CSV file and save them to the configuration.\nSupported headers: host, port, alias, user, password, key, keypass\nEstablishes SSH connections to verify credentials."
 inventory_tag_add_short:
   other: "Add nodes to a tag group"
 inventory_tag_remove_short:
@@ -500,15 +500,39 @@ sudo_exec_failed:
 
 # ---- mcp ----
 mcp_short:
-  other: "Start MCP (Model Context Protocol) server"
+  other: "Manage the MCP (Model Context Protocol) server"
 mcp_long:
   other: "Start an MCP server via Stdio for Agent calls. All regular output and logs will be suppressed."
+mcp_serve_short:
+  other: "Start the MCP server over standard input and output"
+
+# ---- init ----
+init_short:
+  other: "Initialize local XOps configuration"
+init_long:
+  other: "Create the local configuration and encryption key, then import concrete Host entries from OpenSSH configuration. Initialization never connects to remote hosts or overwrites existing nodes."
+flag_init_ssh_config:
+  other: "OpenSSH configuration file to import"
+flag_init_skip_ssh_import:
+  other: "Do not import hosts from OpenSSH configuration"
+init_status_created:
+  other: "XOps initialization complete"
+init_status_existing:
+  other: "XOps configuration already exists; existing content was preserved"
+init_config_path:
+  other: "Configuration: {{.Path}}"
+init_key_path:
+  other: "Encryption key: {{.Path}}"
+init_import_summary:
+  other: "OpenSSH hosts: imported {{.Imported}}, skipped existing {{.Skipped}}"
+init_next_steps:
+  other: "Next: run 'xops host list' to view hosts, or 'xops host add --help' to add one"
 
 # ---- loadHost ----
 loadhost_short:
-  other: "Load hosts from CSV and verify (shortcut for inventory load)"
+  other: "Deprecated: use host import"
 loadhost_long:
-  other: "Load hosts, usernames, and passwords from a CSV file and save to config.\nThis command is a shortcut for 'inventory load'."
+  other: "This compatibility command is deprecated; use 'xops host import'."
 
 # ---- sftp shell ----
 sftp_shell_unknown_cmd:

--- a/pkg/i18n/locales/active.zh.yaml
+++ b/pkg/i18n/locales/active.zh.yaml
@@ -4,9 +4,9 @@
 
 # ---- root ----
 root_short:
-  other: "xops(XOps)是一个命令行工具集,用于日常运维和开发工作"
+  other: "安全管理和自动化远程主机的命令行工具"
 root_long:
-  other: "xops(XOps)是一个命令行工具集,\n提供了多种实用的命令行工具,旨在提高日常运维和开发工作的效率。"
+  other: "XOps 通过统一的主机资产、SSH、批量执行、Playbook 和 MCP 安全护栏，帮助用户安全管理和自动化远程主机。"
 version_short:
   other: "显示版本号"
 flag_version:
@@ -313,9 +313,9 @@ inventory_delete_short:
 inventory_tags_short:
   other: "列出所有标签及对应的节点数量"
 inventory_load_short:
-  other: "从CSV文件加载主机及凭据并验证保存"
+  other: "从 CSV 文件导入主机及凭据并验证保存"
 inventory_load_long:
-  other: "从CSV文件中加载主机、用户名和密码并保存到配置文件中。\n支持表头识别: 主机, 端口, 别名, 用户, 密码, 私钥, 私钥密码\n会建立SSH连接验证凭据的准确性。"
+  other: "从 CSV 文件导入主机、用户名和密码并保存到配置文件中。\n支持表头识别: 主机, 端口, 别名, 用户, 密码, 私钥, 私钥密码\n会建立 SSH 连接验证凭据的准确性。"
 inventory_tag_add_short:
   other: "将节点加入标签组"
 inventory_tag_remove_short:
@@ -501,15 +501,39 @@ sudo_exec_failed:
 
 # ---- mcp ----
 mcp_short:
-  other: "启动 MCP (Model Context Protocol) 服务端"
+  other: "管理 MCP (Model Context Protocol) 服务端"
 mcp_long:
   other: "以标准输入输出 (Stdio) 启动 MCP 服务端，供 Agent 调用。开启后所有常规业务输出与日志将会被屏蔽。"
+mcp_serve_short:
+  other: "通过标准输入输出启动 MCP 服务端"
+
+# ---- init ----
+init_short:
+  other: "初始化 XOps 本地配置"
+init_long:
+  other: "创建本地配置和加密密钥，并从 OpenSSH 配置导入明确的 Host 条目。初始化不会连接任何远程主机，也不会覆盖已有节点。"
+flag_init_ssh_config:
+  other: "要导入的 OpenSSH 配置文件"
+flag_init_skip_ssh_import:
+  other: "不从 OpenSSH 配置导入主机"
+init_status_created:
+  other: "XOps 初始化完成"
+init_status_existing:
+  other: "XOps 配置已存在，已保留现有内容"
+init_config_path:
+  other: "配置文件: {{.Path}}"
+init_key_path:
+  other: "加密密钥: {{.Path}}"
+init_import_summary:
+  other: "OpenSSH 主机: 导入 {{.Imported}}，跳过已有 {{.Skipped}}"
+init_next_steps:
+  other: "下一步: 运行 'xops host list' 查看主机，或运行 'xops host add --help' 添加主机"
 
 # ---- loadHost ----
 loadhost_short:
-  other: "从CSV文件加载主机及凭据并验证保存 (inventory load 的快捷入口)"
+  other: "已弃用：请使用 host import"
 loadhost_long:
-  other: "从CSV文件中加载主机、用户名和密码并保存到配置文件中。\n该命令是 'inventory load' 的快捷方式。"
+  other: "该兼容命令已弃用，请使用 'xops host import'。"
 
 # ---- sftp shell ----
 sftp_shell_unknown_cmd:

--- a/skills/xops-agent/SKILL.md
+++ b/skills/xops-agent/SKILL.md
@@ -13,7 +13,7 @@ Before attempting any operations, please run `xops --version` to check if the to
 If you receive a `command not found` error, instruct the user to execute the following installation command:
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/wentf9/xops-cli/main/install.sh | bash
+curl -sSL https://raw.githubusercontent.com/wentf9/xops-cli/master/install.sh | bash
 ```
 
 ## 🎯 Core Capabilities & Precise Command Usage
@@ -21,6 +21,10 @@ curl -sSL https://raw.githubusercontent.com/wentf9/xops-cli/main/install.sh | ba
 ### 1. Host & Asset Management (`xops host`)
 Manage the inventory of servers, credentials, and grouping tags.
 
+- **Initialize Local Configuration and Import OpenSSH Hosts**:
+  ```bash
+  xops init
+  ```
 - **List All Hosts**:
   ```bash
   xops host list
@@ -31,11 +35,11 @@ Manage the inventory of servers, credentials, and grouping tags.
   ```
 - **Add a New Host**:
   ```bash
-  xops host add --name "web-01" --address "192.168.1.10" --user "root" --password "your_pass" --tag "web"
+  xops host add --address "192.168.1.10" --user "root" --key ~/.ssh/id_ed25519 --alias "web-01" --tags "web"
   ```
-- **Batch Load Hosts from CSV**:
+- **Batch Import Hosts from CSV**:
   ```bash
-  xops loadHost hosts.csv --tag "production"
+  xops host import hosts.csv --tag "production"
   ```
 
 ### 2. Batch Execution (`xops exec`)

--- a/xops_config.example.yaml
+++ b/xops_config.example.yaml
@@ -25,7 +25,7 @@ identities:
     key_path: ~/.ssh/id_ed25519         # 私钥文件路径
     passphrase: ""                      # 私钥密码（为空则无密码）
 
-  # 使用 SSH Agent 认证（无需指定密钥路径，由 SSH Agent 代理）（暂未实现）
+  # 使用 SSH Agent 认证（无需指定密钥路径，由 SSH Agent 代理）
   id-agent:
     user: ubuntu
     auth_type: agent


### PR DESCRIPTION
## Summary

- add an idempotent `xops init` flow that creates local configuration and imports concrete OpenSSH hosts without network access
- make `host`, `host import`, and `mcp serve` the canonical command paths while preserving compatibility aliases
- synchronize Chinese and English CLI help, README examples, configuration comments, and the bundled agent skill
- return configuration read failures instead of silently treating them as an empty configuration

## User impact

New users can initialize XOps from their existing OpenSSH configuration and follow one consistent command structure. Existing `inventory`, `host load`, direct `xops mcp`, and legacy `loadHost` invocations remain compatible.

## Validation

- `go build ./...`
- `go test ./...`
- `golangci-lint run ./...` (0 issues)
- manual CLI help verification for root, `init`, `host import`, and `mcp`
